### PR TITLE
DDSimpleMuonDigi: set ID1 bit to store cellID1

### DIFF
--- a/src/DDSimpleMuonDigi.cc
+++ b/src/DDSimpleMuonDigi.cc
@@ -179,6 +179,7 @@ void DDSimpleMuonDigi::processEvent( LCEvent * evt ) {
   LCFlagImpl flag;
 
   flag.setBit(LCIO::CHBIT_LONG);
+  flag.setBit(LCIO::CHBIT_ID1);
 
   muoncol->setFlag(flag.getFlag());
 


### PR DESCRIPTION

BEGINRELEASENOTES
- DDSimpleMuonDigi: set ID1 bit to store cellID1 for digitized hits

ENDRELEASENOTES