### PR TITLE
Add Werror to CI configuration

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -6,7 +6,7 @@ source $ILCSOFT/init_ilcsoft.sh
 cd /Package
 mkdir build
 cd build
-cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
+cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
 ninja && \
 ninja install && \
 ctest --output-on-failure

--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -7,6 +7,6 @@ cd /Package
 mkdir build
 cd build
 cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
-ninja && \
+ninja -k 0 && \
 ninja install && \
 ctest --output-on-failure


### PR DESCRIPTION

BEGINRELEASENOTES
- Add Werror to CI configuration, no more warnings allowed in DDMarlinPandora

ENDRELEASENOTES