### PR TITLE
DDCaloDigi: add cleanup of PpdDigi objects

### DIFF
--- a/include/DDCaloDigi.h
+++ b/include/DDCaloDigi.h
@@ -190,8 +190,8 @@ class DDCaloDigi : public Processor {
   float _hcalTimeResolution = 10.0;
   bool  _hcalSimpleTimingCut = true;
   
-  DDScintillatorPpdDigi* _scEcalDigi = NULL;
-  DDScintillatorPpdDigi* _scHcalDigi = NULL;
+  std::unique_ptr<DDScintillatorPpdDigi> _scEcalDigi{};
+  std::unique_ptr<DDScintillatorPpdDigi> _scHcalDigi{};
 
 
   // parameters for extra ECAL digitization effects

--- a/src/DDCaloDigi.cc
+++ b/src/DDCaloDigi.cc
@@ -636,7 +636,7 @@ void DDCaloDigi::init() {
   }
   
   // set up the scintillator/MPPC digitiser
-  _scEcalDigi = new DDScintillatorPpdDigi();
+  _scEcalDigi = std::unique_ptr<DDScintillatorPpdDigi>( new DDScintillatorPpdDigi() );
   _scEcalDigi->setPEperMIP(_ecal_PPD_pe_per_mip);
   _scEcalDigi->setCalibMIP(_calibEcalMip);
   _scEcalDigi->setNPix(_ecal_PPD_n_pixels);
@@ -647,7 +647,7 @@ void DDCaloDigi::init() {
   cout << "ECAL sc digi:" << endl;
   _scEcalDigi->printParameters();
 
-  _scHcalDigi = new DDScintillatorPpdDigi();
+  _scHcalDigi = std::unique_ptr<DDScintillatorPpdDigi>( new DDScintillatorPpdDigi() );
   _scHcalDigi->setPEperMIP(_hcal_PPD_pe_per_mip);
   _scHcalDigi->setCalibMIP(_calibHcalMip);
   _scHcalDigi->setNPix(_hcal_PPD_n_pixels);


### PR DESCRIPTION
Getting rid of the last "definite" leaks in reconstruction

BEGINRELEASENOTES
- DDCaloDigi: add cleanup of PpdDigi objects, fixes small memory leak

ENDRELEASENOTES