### PR TITLE
Multiple track states for  TrackClusterMatching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,10 @@ FIND_PACKAGE( PandoraSDK 03.00.00 REQUIRED )
 FIND_PACKAGE( LCContent 03.00.00 REQUIRED )
 FIND_PACKAGE( DD4hep REQUIRED )
 FIND_PACKAGE( ROOT REQUIRED )
+FIND_PACKAGE( MarlinTrk REQUIRED )
 
 
-FOREACH( pkg PandoraSDK Marlin MarlinUtil  LCContent DD4hep ROOT)
+FOREACH( pkg PandoraSDK Marlin MarlinUtil  LCContent DD4hep ROOT MarlinTrk )
     IF( ${pkg}_FOUND )
         INCLUDE_DIRECTORIES( SYSTEM ${${pkg}_INCLUDE_DIRS} )
         LINK_LIBRARIES( ${${pkg}_LIBRARIES} )

--- a/include/DDTrackCreatorBase.h
+++ b/include/DDTrackCreatorBase.h
@@ -30,6 +30,7 @@ typedef std::map<EVENT::Track *, int> TrackToPidMap;
 
 namespace lc_content{
   class LCTrackParameters;
+  class LCTrackFactory;
 }
 namespace MarlinTrk{
   class IMarlinTrkSystem;
@@ -196,7 +197,8 @@ protected:
     float                   m_minimalTrackStateRadiusSquared;         ///< minimal track state radius, derived value
     std::shared_ptr<MarlinTrk::IMarlinTrkSystem> m_trackingSystem={}; ///< Tracking system used for track states
     std::shared_ptr<UTIL::BitField64> m_encoder={};                   ///< cell ID encoder
-    
+    std::shared_ptr<lc_content::LCTrackFactory> m_lcTrackFactory={};  ///< LCTrackFactor for creating LCTracks
+
     
     ///Nikiforos: Need to implement following abstract functions according to detector model
     

--- a/include/DDTrackCreatorBase.h
+++ b/include/DDTrackCreatorBase.h
@@ -20,9 +20,20 @@
 #include "Api/PandoraApi.h"
 #include "Objects/Helix.h"
 
+#include <UTIL/ILDConf.h>
+
+#include <memory>
+
 typedef std::vector<EVENT::Track *> TrackVector;
 typedef std::set<const EVENT::Track *> TrackList;
 typedef std::map<EVENT::Track *, int> TrackToPidMap;
+
+namespace lc_content{
+  class LCTrackParameters;
+}
+namespace MarlinTrk{
+  class IMarlinTrkSystem;
+}
 
 inline IMPL::LCCollectionVec *newTrkCol(const std::string &name, EVENT::LCEvent *evt , bool isSubset)
 {
@@ -99,7 +110,10 @@ public:
         float           m_maxBarrelTrackerInnerRDistance;                 ///< Track cut on distance from barrel tracker inner r to id whether track can form pfo
         float           m_minBarrelTrackerHitFractionOfExpected;          ///< Minimum fraction of TPC hits compared to expected
         int             m_minFtdHitsForBarrelTrackerHitFraction;          ///< Minimum number of FTD hits to ignore TPC hit fraction
-        
+        float           m_trackStateTolerance; ///< distance below tracker ecal radius the second trackstate in the ecal endcap is still passed to pandora
+        std::string     m_trackingSystemName;  ///< name of the tracking system used for getting new track states
+
+
         ///Nikiforos: Moved from main class
         
         float             m_bField;                       ///< The bfield
@@ -147,6 +161,16 @@ public:
      */
     const TrackVector &GetTrackVector() const;
 
+
+    /**
+     *  @brief  Calculate possible second track state at the ECal Endcap
+     *
+     *  @param track lcio track
+     *  @param trackParameters pandora LCTrackParameters
+     */
+    virtual void GetTrackStatesAtCalo( EVENT::Track *track, lc_content::LCTrackParameters& trackParameters);
+
+
     /**
      *  @brief  Reset the track creator
      */
@@ -169,6 +193,9 @@ protected:
     TrackList               m_parentTrackList;              ///< The list of parent tracks
     TrackList               m_daughterTrackList;            ///< The list of daughter tracks
     TrackToPidMap           m_trackToPidMap;                ///< The map from track addresses to particle ids, where set by kinks/V0s
+    float                   m_minimalTrackStateRadiusSquared;         ///< minimal track state radius, derived value
+    std::shared_ptr<MarlinTrk::IMarlinTrkSystem> m_trackingSystem={}; ///< Tracking system used for track states
+    std::shared_ptr<UTIL::BitField64> m_encoder={};                   ///< cell ID encoder
     
     
     ///Nikiforos: Need to implement following abstract functions according to detector model

--- a/src/DDPandoraPFANewProcessor.cc
+++ b/src/DDPandoraPFANewProcessor.cc
@@ -665,7 +665,16 @@ void DDPandoraPFANewProcessor::ProcessSteeringFile()
                             m_trackCreatorSettings.m_maxBarrelTrackerInnerRDistance,
                             float(50.));
 
-   
+    registerProcessorParameter( "TrackStateTolerance",
+                                "Distance of possible second track state in the ECal Endcap to the ECal barrel inner radius",
+                                m_trackCreatorSettings.m_trackStateTolerance,
+                                m_trackCreatorSettings.m_trackStateTolerance );
+
+    registerProcessorParameter( "TrackSystemName",
+                                "Name of the track fitting system to be used (KalTest, DDKalTest, aidaTT, ... )",
+                                m_trackCreatorSettings.m_trackingSystemName,
+                                m_trackCreatorSettings.m_trackingSystemName );
+
     // For Strip Splitting method and also for hybrid ECAL
     registerProcessorParameter("StripSplittingOn",
                             "To use strip splitting algorithm, this should be true",

--- a/src/DDTrackCreatorBase.cc
+++ b/src/DDTrackCreatorBase.cc
@@ -54,7 +54,7 @@ DDTrackCreatorBase::DDTrackCreatorBase(const Settings &settings, const pandora::
                                                     [](MarlinTrk::IMarlinTrkSystem*){} );
     m_trackingSystem->init();
     m_encoder = std::make_shared<UTIL::BitField64>( lcio::LCTrackerCellID::encoding_string() );
-
+    m_lcTrackFactory = std::make_shared<lc_content::LCTrackFactory>();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/DDTrackCreatorBase.cc
+++ b/src/DDTrackCreatorBase.cc
@@ -390,13 +390,13 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo( EVENT::Track *track,
                                                lc_content::LCTrackParameters& trackParameters ){
 
   if( not trackParameters.m_reachesCalorimeter.Get() ) {
-      streamlog_out(DEBUG4) << "Track does not reach the ECal" <<std::endl;
+      streamlog_out(DEBUG5) << "Track does not reach the ECal" <<std::endl;
     return;
   }
 
   const TrackState *trackAtCalo = track->getTrackState(TrackState::AtCalorimeter);
   if( not trackAtCalo ) {
-      streamlog_out(DEBUG4) << "Track does not have a trackState at calorimeter" <<std::endl;
+      streamlog_out(DEBUG5) << "Track does not have a trackState at calorimeter" <<std::endl;
       streamlog_out(DEBUG3) << toString(track) << std::endl;
       return;
   }
@@ -406,12 +406,12 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo( EVENT::Track *track,
   const auto* tsPosition = trackAtCalo->getReferencePoint();
 
   if( tsPosition[2] <  getTrackingRegionExtent()[2] ) {
-      streamlog_out(DEBUG4) << "Original trackState is at Barrel" << std::endl;
+      streamlog_out(DEBUG5) << "Original trackState is at Barrel" << std::endl;
       pandora::InputTrackState pandoraTrackState;
       this->CopyTrackState( trackAtCalo, pandoraTrackState );
       trackParameters.m_trackStates.push_back( pandoraTrackState );
   } else { // if track state is in endcap we do not repeat track state calculation, because the barrel cannot be hit
-      streamlog_out(DEBUG4) << "Original track state is at Endcap" << std::endl;
+      streamlog_out(DEBUG5) << "Original track state is at Endcap" << std::endl;
       pandora::InputTrackState pandoraTrackState;
       this->CopyTrackState( trackAtCalo, pandoraTrackState );
       trackParameters.m_trackStates.push_back( pandoraTrackState );
@@ -445,14 +445,14 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo( EVENT::Track *track,
 
   return_error = marlintrk->propagateToLayer(m_encoder->lowWord(), trackStateAtCaloEndcap, chi2, ndf,
                                              detElementID, MarlinTrk::IMarlinTrack::modeForward );
-  streamlog_out(DEBUG4) << "Found trackState at endcap? Error code: " << return_error  << std::endl;
+  streamlog_out(DEBUG5) << "Found trackState at endcap? Error code: " << return_error  << std::endl;
 
   if (return_error == MarlinTrk::IMarlinTrack::success ) {
       streamlog_out(DEBUG3) << "Endcap" << toString(&trackStateAtCaloEndcap) << std::endl;
       const auto* tsEP = trackStateAtCaloEndcap.getReferencePoint();
       const double radSquared = ( tsEP[0]*tsEP[0] + tsEP[1]*tsEP[1] );
       if( radSquared < m_minimalTrackStateRadiusSquared ) {
-          streamlog_out(DEBUG4) << "new track state is below tolerance radius" << std::endl;
+          streamlog_out(DEBUG5) << "new track state is below tolerance radius" << std::endl;
           return;
       }
       //for curling tracks the propagated track has the wrong z0 whereas it should be 0. really
@@ -460,7 +460,7 @@ void DDTrackCreatorBase::GetTrackStatesAtCalo( EVENT::Track *track,
           std::abs( 2.*M_PI/trackStateAtCaloEndcap.getOmega() * trackStateAtCaloEndcap.getTanLambda() ) ){
           trackStateAtCaloEndcap.setZ0( 0. );
       }
-      streamlog_out(DEBUG4) << "new track state at endcap accepted" << std::endl;
+      streamlog_out(DEBUG5) << "new track state at endcap accepted" << std::endl;
       pandora::InputTrackState pandoraAtEndcap;
       this->CopyTrackState( &trackStateAtCaloEndcap, pandoraAtEndcap );
       trackParameters.m_trackStates.push_back( pandoraAtEndcap );

--- a/src/DDTrackCreatorCLIC.cc
+++ b/src/DDTrackCreatorCLIC.cc
@@ -246,7 +246,7 @@ pandora::StatusCode DDTrackCreatorCLIC::CreateTracks(EVENT::LCEvent *pLCEvent)
 		      {
 			streamlog_out(ERROR) << "Failed to extract a track: " << statusCodeException.ToString() << std::endl;
 			
-			streamlog_out( DEBUG5 ) << " failed track : " << *pTrack << std::endl ;
+			streamlog_out( DEBUG3 ) << " failed track : " << *pTrack << std::endl ;
 		      }
 		    catch (EVENT::Exception &exception)
 		      {
@@ -274,7 +274,7 @@ bool DDTrackCreatorCLIC::PassesQualityCuts(const EVENT::Track *const pTrack, con
     // First simple sanity checks
     if (trackParameters.m_trackStateAtCalorimeter.Get().GetPosition().GetMagnitude() < m_settings.m_minTrackECalDistanceFromIp){
         streamlog_out(WARNING) << " Dropping track! Distance at ECAL: " << trackParameters.m_trackStateAtCalorimeter.Get().GetPosition().GetMagnitude()<<std::endl;
-	streamlog_out(DEBUG5)  << " track : " << *pTrack
+	streamlog_out(DEBUG3)  << " track : " << *pTrack
 			       << std::endl;
         return false;
     }
@@ -295,12 +295,12 @@ bool DDTrackCreatorCLIC::PassesQualityCuts(const EVENT::Track *const pTrack, con
                                << " chi2 = " <<  pTrack->getChi2() << " " << pTrack->getNdf()
                                << " from " << pTrack->getTrackerHits().size()  << std::endl ;
 
-	streamlog_out(DEBUG5)  << " track : " << *pTrack
+	streamlog_out(DEBUG3)  << " track : " << *pTrack
 			       << std::endl;
         return false;
     }
 
-    streamlog_out( DEBUG5 ) << " TEMPORARILY ACCEPT TRACK WITHOUT CUTS (should change!)" << *pTrack << std::endl ;
+    streamlog_out( DEBUG3 ) << " TEMPORARILY ACCEPT TRACK WITHOUT CUTS (should change!)" << *pTrack << std::endl ;
     return true;
     
     // Require reasonable number of Tracker hits 
@@ -367,7 +367,7 @@ bool DDTrackCreatorCLIC::PassesQualityCuts(const EVENT::Track *const pTrack, con
             streamlog_out(WARNING) << " Dropping track : " << momentumAtDca.GetMagnitude() << " Number of Tracker hits = " << nBarrelTrackerHits
                                    << " < " << minTrackerHits << " nendcapDisk = " << nEndcapTrackerHits << std::endl;
 
-	    streamlog_out(DEBUG5)  << " track : " << *pTrack
+	    streamlog_out(DEBUG3)  << " track : " << *pTrack
 				   << std::endl;
             return false;
         }

--- a/src/DDTrackCreatorCLIC.cc
+++ b/src/DDTrackCreatorCLIC.cc
@@ -151,8 +151,6 @@ DDTrackCreatorCLIC::~DDTrackCreatorCLIC()
 pandora::StatusCode DDTrackCreatorCLIC::CreateTracks(EVENT::LCEvent *pLCEvent)
 {
 
-    lc_content::LCTrackFactory lcTrackFactory;
-
     for (StringVector::const_iterator iter = m_settings.m_trackCollections.begin(), iterEnd = m_settings.m_trackCollections.end();
         iter != iterEnd; ++iter)
     {
@@ -239,7 +237,7 @@ pandora::StatusCode DDTrackCreatorCLIC::CreateTracks(EVENT::LCEvent *pLCEvent)
 			this->GetTrackStatesAtCalo(pTrack, trackParameters);
 			this->DefineTrackPfoUsage(pTrack, trackParameters);
 
-			PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Track::Create(m_pandora, trackParameters, lcTrackFactory));
+			PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Track::Create(m_pandora, trackParameters, *m_lcTrackFactory));
 			m_trackVector.push_back(pTrack);
 		      }
 		    catch (pandora::StatusCodeException &statusCodeException)

--- a/src/DDTrackCreatorCLIC.cc
+++ b/src/DDTrackCreatorCLIC.cc
@@ -18,6 +18,7 @@
 #include "UTIL/Operators.h"
 
 #include "Pandora/PdgTable.h"
+#include "LCObjects/LCTrack.h"
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
@@ -149,6 +150,9 @@ DDTrackCreatorCLIC::~DDTrackCreatorCLIC()
 
 pandora::StatusCode DDTrackCreatorCLIC::CreateTracks(EVENT::LCEvent *pLCEvent)
 {
+
+    lc_content::LCTrackFactory lcTrackFactory;
+
     for (StringVector::const_iterator iter = m_settings.m_trackCollections.begin(), iterEnd = m_settings.m_trackCollections.end();
         iter != iterEnd; ++iter)
     {
@@ -198,7 +202,7 @@ pandora::StatusCode DDTrackCreatorCLIC::CreateTracks(EVENT::LCEvent *pLCEvent)
 //                     }
 
                     // Proceed to create the pandora track
-                    PandoraApi::Track::Parameters trackParameters;
+                    lc_content::LCTrackParameters trackParameters;
                     trackParameters.m_d0 = pTrack->getD0();
                     trackParameters.m_z0 = pTrack->getZ0();
                     trackParameters.m_pParentAddress = pTrack;
@@ -232,9 +236,10 @@ pandora::StatusCode DDTrackCreatorCLIC::CreateTracks(EVENT::LCEvent *pLCEvent)
 
 			this->GetTrackStates(pTrack, trackParameters);
 			this->TrackReachesECAL(pTrack, trackParameters);
+			this->GetTrackStatesAtCalo(pTrack, trackParameters);
 			this->DefineTrackPfoUsage(pTrack, trackParameters);
 
-			PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Track::Create(m_pandora, trackParameters));
+			PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Track::Create(m_pandora, trackParameters, lcTrackFactory));
 			m_trackVector.push_back(pTrack);
 		      }
 		    catch (pandora::StatusCodeException &statusCodeException)

--- a/src/DDTrackCreatorILD.cc
+++ b/src/DDTrackCreatorILD.cc
@@ -17,6 +17,7 @@
 
 #include "DDTrackCreatorILD.h"
 #include "Pandora/PdgTable.h"
+#include "LCObjects/LCTrack.h"
 
 #include <algorithm>
 #include <cmath>
@@ -225,7 +226,7 @@ pandora::StatusCode DDTrackCreatorILD::CreateTracks(EVENT::LCEvent *pLCEvent)
 		continue;
 
 	      // Proceed to create the pandora track
-	      PandoraApi::Track::Parameters trackParameters;
+	      lc_content::LCTrackParameters trackParameters;
 	      trackParameters.m_d0 = pTrack->getD0();
 	      trackParameters.m_z0 = pTrack->getZ0();
 	      trackParameters.m_pParentAddress = pTrack;
@@ -250,9 +251,10 @@ pandora::StatusCode DDTrackCreatorILD::CreateTracks(EVENT::LCEvent *pLCEvent)
 		{
 		  this->GetTrackStates(pTrack, trackParameters);
 		  this->TrackReachesECAL(pTrack, trackParameters);
+		  this->GetTrackStatesAtCalo(pTrack, trackParameters);
 		  this->DefineTrackPfoUsage(pTrack, trackParameters);
 
-		  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Track::Create(m_pandora, trackParameters));
+		  PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Track::Create(m_pandora, trackParameters, *m_lcTrackFactory));
 		  m_trackVector.push_back(pTrack);
 		}
 	      catch (pandora::StatusCodeException &statusCodeException)


### PR DESCRIPTION

BEGINRELEASENOTES
- DDTrackCreator: implement passing of multiple track states to Pandora, needs PandoraPFA/LCContent#16
- Implemented DDTrackCreatorBase::GetTrackStatesAtCalo to obtain second trackstate in the endcap
- Added GetTrackStatesAtCalo and related code in DDTrackCreatorCLIC and DDTrackCreatorILD

- DDPandoraPFANewProcessor: 
  * added *TrackStateTolerance* variable to tweak the radius until trackStates in the ECal endcap are accepted, by default only trackStates with a radius larger than EcalBarrel Inner radius are accepted
  * added *TrackSystemName* parameter to chose trackSystem (DDKalTest) to use for trackState calculation

ENDRELEASENOTES

For my test sample of 2000 10GeV pions in the relevant direction (34 to 36 degrees polar angle) of the CLIC_o3_v13 detector I find the following number of reconstructed particles

| Particle | Before | After |
| --- | ---: | ---: |
| Neutron |  185 |    9 |
|   Gamma |   90 |   58 |
|   Electron |   29 |   35 |
|   Muon |   20 |   22 |
|  Pi- | 1676 | 1876 |

A lot less neutrons, so cluster are better matched now. I have only compared the first entries from the ReconstructedParticle collection, so the reconstruction performance is probably even better than what is shown in the table. Sometimes particles shower before reaching the calorimeter, so perfect results cannot be expected.
