### PR TITLE
rm unused and deprected DDRec/API/Calorimeter.h

### DIFF
--- a/src/DDCaloDigi.cc
+++ b/src/DDCaloDigi.cc
@@ -33,7 +33,6 @@
 #include "DDRec/DetectorData.h"
 #include "DDRec/DDGear.h"
 #include "DDRec/MaterialManager.h"
-#include "DDRec/API/Calorimeter.h"
 
 using namespace std;
 using namespace lcio ;


### PR DESCRIPTION

BEGINRELEASENOTES
- rm unused and deprecated DDRec/API/Calorimeter.h 
     - (see https://github.com/AIDASoft/DD4hep/pull/241)

ENDRELEASENOTES