### PR TITLE
Hit time computation in DDSimpleMuonDigi

### DIFF
--- a/include/DDSimpleMuonDigi.h
+++ b/include/DDSimpleMuonDigi.h
@@ -64,6 +64,7 @@ class DDSimpleMuonDigi : public Processor {
   std::string _cellIDLayerString = "layer";
 
   float _thresholdMuon = 0.025;
+  float _timeThresholdMuon = _thresholdMuon ;
   float _calibrCoeffMuon = 120000;
   float _maxHitEnergyMuon = 2.0;
 

--- a/include/DDSimpleMuonDigi.h
+++ b/include/DDSimpleMuonDigi.h
@@ -12,6 +12,10 @@
 using namespace lcio ;
 using namespace marlin ;
 
+namespace EVENT {
+  class SimCalorimeterHit ;
+}
+
 
 /** === DDSimpleMuonDigi Processor === <br>
  *  Simple calorimeter digitizer for the muon detectors.
@@ -42,6 +46,7 @@ class DDSimpleMuonDigi : public Processor {
   virtual void end() ;
 
   bool useLayer(CHT::Layout caloLayout, unsigned int layer) ;
+  float computeHitTime( const EVENT::SimCalorimeterHit *h ) const ;
   
  protected:
 

--- a/src/DDSimpleMuonDigi.cc
+++ b/src/DDSimpleMuonDigi.cc
@@ -59,6 +59,11 @@ DDSimpleMuonDigi::DDSimpleMuonDigi() : Processor("DDSimpleMuonDigi") {
 			     _thresholdMuon,
 			     (float)0.025);
 
+    registerProcessorParameter("MuonTimeThreshold" ,
+			     "Energy threshold for timing information for Muon Hits in GeV" ,
+			     _timeThresholdMuon,
+			     (float)0.025);
+
   registerProcessorParameter("CalibrMUON" , 
 			     "Calibration coefficients for MUON" ,
 			     _calibrCoeffMuon,
@@ -155,7 +160,6 @@ void DDSimpleMuonDigi::init() {
       }
     }
   }
-
 
 
 }
@@ -282,7 +286,7 @@ float DDSimpleMuonDigi::computeHitTime( const EVENT::SimCalorimeterHit *h ) cons
   float energySum = 0.f ;
   for(auto &entry : timeToEnergyMapping ) {
     energySum += entry.second * _calibrCoeffMuon;
-    if( energySum > _thresholdMuon ) {
+    if( energySum > _timeThresholdMuon ) {
       return entry.first ;
     }
   }

--- a/src/DDSimpleMuonDigi.cc
+++ b/src/DDSimpleMuonDigi.cc
@@ -272,8 +272,9 @@ float DDSimpleMuonDigi::computeHitTime( const EVENT::SimCalorimeterHit *h ) cons
   // Sort sim hit MC contribution by time.
   // Accumulate the energy from earliest time till the energy
   // threshold is reached. The hit time is then estimated at this position in the array 
-  std::vector<std::pair<float, float>> timeToEnergyMapping {} ;
   using entry_type = std::pair<float, float> ;
+  std::vector<entry_type> timeToEnergyMapping {} ;
+
   const unsigned int nContribs = h->getNMCContributions() ;
   timeToEnergyMapping.reserve( nContribs ) ;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSimpleMuonDigi processor: 
   - added time computation
      - Sort MC contribution by time
      - Accumulate energy until the threshold is reached
      - Return the corresponding MC contribution time
   - added new parameter MuonTimeThreshold: the muon energy threshold for estimating the hit time

ENDRELEASENOTES