### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,18 @@
+name: keyh4ep
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: ["release", "nightly"]
+        image: ["alma9", "ubuntu22", "centos7"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: key4hep/key4hep-actions/key4hep-build@main
+      with:
+        build_type: ${{ matrix.build_type }}
+        image: ${{ matrix.image }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,16 +7,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPILER: [gcc10, clang11]
-        LCG: [100]
-        include:
-          - COMPILER: gcc8
-            LCG: 99python2
+        COMPILER: [gcc11]
+        LCG: [104]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/${{ matrix.LCG }}/nightly/x86_64-centos7-${{ matrix.COMPILER }}-opt"
         setup-script: "init_ilcsoft.sh"
@@ -27,3 +24,5 @@ jobs:
           ninja -k0
           ctest --output-on-failure
           ninja install
+name: linux
+on: [push, pull_request]


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to latest clicdp nightlies based releases
- Add a `key4hep-build` based workflow to build against Key4hep stacks.

ENDRELEASENOTES