### PR TITLE
Add a non-linearity correction plugin for the ECAL

### DIFF
--- a/include/DDPandoraPFANewProcessor.h
+++ b/include/DDPandoraPFANewProcessor.h
@@ -54,6 +54,9 @@ public:
 
         FloatVector     m_inputEnergyCorrectionPoints{};    ///< The input energy points for non-linearity energy correction
         FloatVector     m_outputEnergyCorrectionPoints{};   ///< The output energy points for non-linearity energy correction
+
+        FloatVector m_ecalInputEnergyCorrectionPoints{};    ///< The input energy points for non-linearity energy correction in the ECAL
+        FloatVector m_ecalOutputEnergyCorrectionPoints{};   ///< The input energy points for non-linearity energy correction in the ECAL
         
         // Software compensation parameters
         FloatVector     m_softCompParameters{};

--- a/src/DDPandoraPFANewProcessor.cc
+++ b/src/DDPandoraPFANewProcessor.cc
@@ -313,6 +313,9 @@ pandora::StatusCode DDPandoraPFANewProcessor::RegisterUserComponents() const
     PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, LCContent::RegisterNonLinearityEnergyCorrection(*m_pPandora,
         "NonLinearity", pandora::HADRONIC, m_settings.m_inputEnergyCorrectionPoints, m_settings.m_outputEnergyCorrectionPoints));
 
+    PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, LCContent::RegisterNonLinearityEnergyCorrection(*m_pPandora,
+        "ECALClusterCorrection", pandora::ELECTROMAGNETIC, m_settings.m_ecalInputEnergyCorrectionPoints, m_settings.m_ecalOutputEnergyCorrectionPoints));
+
     PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::RegisterAlgorithmFactory(*m_pPandora,
         "ExternalClustering", new DDExternalClusteringAlgorithm::Factory));
     
@@ -795,6 +798,17 @@ void DDPandoraPFANewProcessor::ProcessSteeringFile()
                             m_settings.m_outputEnergyCorrectionPoints,
                             FloatVector());
     
+    // ECAL energy non-linearity correction
+    registerProcessorParameter("ECALInputEnergyCorrectionPoints",
+                            "The input energy points for electromagnetic energy correction",
+                            m_settings.m_ecalInputEnergyCorrectionPoints,
+                            FloatVector());
+
+    registerProcessorParameter("ECALOutputEnergyCorrectionPoints",
+                            "The output energy points for electromagnetic energy correction",
+                            m_settings.m_ecalOutputEnergyCorrectionPoints,
+                            FloatVector());
+
     
     ///EXTRA PARAMETERS FROM NIKIFOROS
     registerProcessorParameter("TrackCreatorName",


### PR DESCRIPTION

BEGINRELEASENOTES
- Make it possible to register ECAL energy corrections with Pandora similar to what is possible for the HCAL

ENDRELEASENOTES